### PR TITLE
Call Log.CloseAndFlush on application exit

### DIFF
--- a/DShop.Api.sln
+++ b/DShop.Api.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.156
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{46EAF82A-F107-4840-8ADA-6D05BDBA61EE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DShop.Api", "src\DShop.Api\DShop.Api.csproj", "{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DShop.Api", "src\DShop.Api\DShop.Api.csproj", "{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -16,24 +16,27 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Debug|x64.ActiveCfg = Debug|x64
-		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Debug|x64.Build.0 = Debug|x64
-		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Debug|x86.ActiveCfg = Debug|x86
-		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Debug|x86.Build.0 = Debug|x86
+		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Debug|x64.Build.0 = Debug|Any CPU
+		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Debug|x86.Build.0 = Debug|Any CPU
 		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Release|Any CPU.Build.0 = Release|Any CPU
-		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Release|x64.ActiveCfg = Release|x64
-		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Release|x64.Build.0 = Release|x64
-		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Release|x86.ActiveCfg = Release|x86
-		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Release|x86.Build.0 = Release|x86
+		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Release|x64.ActiveCfg = Release|Any CPU
+		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Release|x64.Build.0 = Release|Any CPU
+		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Release|x86.ActiveCfg = Release|Any CPU
+		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{CE38CFE2-4DF0-4E7F-99E4-9E78BC377553} = {46EAF82A-F107-4840-8ADA-6D05BDBA61EE}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DBFE3BA0-2512-4AC3-983A-293EB6C4F6B3}
 	EndGlobalSection
 EndGlobal

--- a/src/DShop.Api/Program.cs
+++ b/src/DShop.Api/Program.cs
@@ -5,6 +5,7 @@ using DShop.Common.Metrics;
 using DShop.Common.Mvc;
 using DShop.Common.Vault;
 using System;
+using Serilog;
 
 namespace DShop.Api
 {
@@ -12,7 +13,18 @@ namespace DShop.Api
     {
         public static void Main(string[] args)
         {
-            CreateWebHostBuilder(args).Build().Run();
+            try
+            { 
+                CreateWebHostBuilder(args).Build().Run();
+            }
+            catch(Exception ex)
+            {
+                Log.Fatal(ex, "Host terminted unexpectedly");
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+            }
         }
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>


### PR DESCRIPTION
Close and Flush Serilog to properly log all shutdown events. This could be handled in the DShop.Common project by passing true as the second parameter to UseSerilog. However, that has other consequences for the applications that use DShop.Common. 